### PR TITLE
Provide more space for the title

### DIFF
--- a/widgets/valetudo-standalone.yml
+++ b/widgets/valetudo-standalone.yml
@@ -78,7 +78,7 @@ slots:
         default:
           - component: f7-col
             config:
-              width: 60
+              width: 90
               style:
                 padding: 10px
             slots:


### PR DESCRIPTION
The previous setting (60) caused the title to be ellipsized.  The new value (90) gives proper results for me, none of my vacuums have their titles + statuses abbreviated.